### PR TITLE
Auto-registration of commands is deprecated

### DIFF
--- a/src/Voryx/RESTGeneratorBundle/Command/GenerateDoctrineRESTCommand.php
+++ b/src/Voryx/RESTGeneratorBundle/Command/GenerateDoctrineRESTCommand.php
@@ -30,6 +30,9 @@ class GenerateDoctrineRESTCommand extends GenerateDoctrineCrudCommand
      */
     private $formGenerator;
 
+    /** @var string $defaultName */
+    protected static $defaultName = 'voryx:generate:rest'; // Make command lazy load
+
     /**
      * @see Command
      */
@@ -65,7 +68,7 @@ You can check https://github.com/sensio/SensioGeneratorBundle/tree/master/Resour
 in order to know the file structure of the skeleton
 EOT
             )
-            ->setName('voryx:generate:rest')
+            ->setName(self::$defaultName)
             ->setAliases(array('generate:voryx:rest'));
     }
 

--- a/src/Voryx/RESTGeneratorBundle/DependencyInjection/VoryxRESTGeneratorExtension.php
+++ b/src/Voryx/RESTGeneratorBundle/DependencyInjection/VoryxRESTGeneratorExtension.php
@@ -24,5 +24,6 @@ class VoryxRESTGeneratorExtension extends Extension
 
         $loader = new Loader\XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
         $loader->load('services.xml');
+        $loader->load('commands.xml');
     }
 }

--- a/src/Voryx/RESTGeneratorBundle/Resources/config/commands.xml
+++ b/src/Voryx/RESTGeneratorBundle/Resources/config/commands.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="voryx_restgenerator.command.rest_generate" class="Voryx\RESTGeneratorBundle\Command\GenerateDoctrineRESTCommand">
+            <tag name="console.command" command="voryx:generate:rest" />
+        </service>
+    </services>
+
+</container>


### PR DESCRIPTION
Fixes "Auto-registration of the command "Voryx\RESTGeneratorBundle\Command\GenerateDoctrineRESTCommand" is deprecated since Symfony 3.4 and won't be supported in 4.0